### PR TITLE
Add toggleable config panel with header gear

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
 <body>
   <header>
     <h1>Cruzada (30×30) • OnePage com Canvas + <span style="color:var(--accent)">WordPlacer</span></h1>
+    <button id="cfgToggle">⚙️</button>
   </header>
 
-  <div class="wrap">
-    <!-- Painel esquerdo: controles -->
+  <div id="configPanel">
     <section class="panel" id="controls">
       <h2>Configurações</h2>
 
@@ -65,7 +65,9 @@
 
       <div class="row help">Dica: a <strong>primeira palavra</strong> fica com a <em>letra do meio</em> no centro do grid (para pares, usamos o índice <code>Math.floor((len-1)/2)</code>). A orientação alterna entre cada palavra.</div>
     </section>
+  </div>
 
+  <div class="wrap">
     <!-- Painel direito: canvas + logs -->
     <section class="grid-wrap">
       <div class="panel" style="flex:1; display:flex; flex-direction:column; gap:10px;">

--- a/script.js
+++ b/script.js
@@ -316,6 +316,8 @@
         logs: document.getElementById('logs'),
         summary: document.getElementById('summary'),
       };
+      const cfgToggle = document.getElementById('cfgToggle');
+      const configPanel = document.getElementById('configPanel');
   
       const defaultDict = ["casa","computador","livro","sol","mesa","janela","porta","carro","amigo","floresta","rio","luz","tempo","caminho","sorriso","brasil","noite","tarde","manhã","cidade","praia","montanha","vila","cachorro","gato","festa","musica","vento","chuva","neve"];
   
@@ -402,6 +404,9 @@
       // Eventos
       els.btnGenerate.addEventListener('click', generate);
       els.btnReset.addEventListener('click', resetAll);
-  
+      cfgToggle.addEventListener('click', () => {
+        configPanel.classList.toggle('open');
+      });
+
       // Render inicial
       resetAll();

--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,28 @@
     padding:16px 20px; border-bottom:1px solid #1f2937; position:sticky; top:0; backdrop-filter:saturate(1.1) blur(6px); background:rgba(7,12,30,.6);
   }
   h1{margin:0; font-size:18px; letter-spacing:.2px}
-  .wrap{display:grid; gap:16px; grid-template-columns: 360px 1fr; padding:16px;}
+  .wrap{padding:16px;}
+  #configPanel{
+    position:fixed;
+    top:0;
+    left:0;
+    height:100%;
+    width:360px;
+    padding:16px;
+    transform:translateX(-100%);
+    transition:transform .3s ease;
+  }
+  #configPanel.open{transform:translateX(0);}
+  #cfgToggle{
+    position:absolute;
+    top:16px;
+    right:20px;
+    background:none;
+    border:0;
+    font-size:20px;
+    color:var(--ink);
+    cursor:pointer;
+  }
   .panel{background:rgba(17,24,39,.7); border:1px solid #1f2937; border-radius:16px; padding:14px}
   .panel h2{margin:0 0 10px 0; font-size:14px; color:var(--muted); font-weight:600; letter-spacing:.3px}
   .row{display:flex; gap:8px; align-items:center; margin:8px 0}


### PR DESCRIPTION
## Summary
- Add gear toggle button in header and move controls into new off-canvas config panel
- Style config panel to slide in from the left and adjust layout
- Wire up toggle button to open/close panel via JavaScript

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c255a30832e80c023d447aa433d