### PR TITLE
Improve layout for paired numeric inputs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -60,3 +60,6 @@
   .kvs{display:grid; grid-template-columns: 1fr auto; gap:6px}
   .help{font-size:12px; color:#a5b4fc}
   .two{display:grid; grid-template-columns:1fr 1fr; gap:8px}
+  .two .row{flex-direction:column; align-items:flex-start}
+  .two .row label{min-width:unset}
+  .two .row input[type="number"]{max-width:100%}


### PR DESCRIPTION
## Summary
- Adjust rows inside `.two` sections to stack labels above inputs and align left
- Remove label width constraint within `.two` for full-width inputs and cap numeric input width

## Testing
- ⚠️ `npm test` *(missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8e83177c832ea20c289827a17f5c