### PR TITLE
Refine help text layout for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         <button id="btnReset" class="secondary">Limpar</button>
       </div>
 
-      <div class="row help">Dica: a <strong>primeira palavra</strong> fica com a <em>letra do meio</em> no centro do grid (para pares, usamos o índice <code>Math.floor((len-1)/2)</code>). A orientação alterna entre cada palavra.</div>
+      <p class="help">Dica: a <strong>primeira palavra</strong> fica com a <em>letra do meio</em> no centro do grid (para pares, usamos o índice <code>Math.floor((len-1)/2)</code>). A orientação alterna entre cada palavra.</p>
     </section>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -58,5 +58,6 @@
   .list{font-size:12px; color:#cbd5e1}
   .badge{display:inline-block; padding:2px 8px; border-radius:999px; background:#0b1227; border:1px solid #1f2937; margin-left:6px; color:#93c5fd}
   .kvs{display:grid; grid-template-columns: 1fr auto; gap:6px}
-  .help{font-size:12px; color:#a5b4fc}
-  .two{display:grid; grid-template-columns:1fr 1fr; gap:8px}
+    .help{font-size:12px; color:#a5b4fc; white-space:normal; line-height:1.4; margin-top:8px}
+    @media (max-width:768px){.help{max-width:320px; overflow-wrap:anywhere}}
+    .two{display:grid; grid-template-columns:1fr 1fr; gap:8px}


### PR DESCRIPTION
## Summary
- Replace row-based help div with paragraph element to avoid row styling
- Style help text for normal wrapping, comfortable line height, and responsive width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8e903758832e9456377f50275731