### PR TITLE
Simplify interface with start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,81 +6,15 @@
   <title>Cruzada • OnePage (Canvas + WordPlacer)</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <header>
-    <h1>Cruzada (30×30) • OnePage com Canvas + <span style="color:var(--accent)">WordPlacer</span></h1>
-    <button id="cfgToggle">⚙️</button>
-  </header>
+  <body>
+    <div id="startScreen">
+      <button id="startBtn">Iniciar jogo</button>
+    </div>
 
-  <div id="configPanel">
-    <section class="panel" id="controls">
-      <h2>Configurações</h2>
-
-      <div class="row">
-        <label for="gridSize">Tamanho do grid</label>
-        <input type="number" id="gridSize" value="30" min="5" max="80" />
-      </div>
-
-      <div class="two">
-        <div class="row">
-          <label for="minWords">Mín. palavras</label>
-          <input type="number" id="minWords" value="2" min="1" max="20" />
-        </div>
-        <div class="row">
-          <label for="maxWords">Máx. palavras</label>
-          <input type="number" id="maxWords" value="5" min="1" max="50" />
-        </div>
-      </div>
-
-      <div class="two">
-        <div class="row">
-          <label for="cellSize">Tamanho da célula (px)</label>
-          <input type="number" id="cellSize" value="24" min="12" max="40" />
-        </div>
-        <div class="row">
-          <label for="fontScale">Fonte (%)</label>
-          <input type="number" id="fontScale" value="70" min="40" max="100" />
-        </div>
-      </div>
-
-      <div class="row">
-        <label for="seed">Seed (opcional)</label>
-        <input type="text" id="seed" placeholder="Ex.: 12345" />
-      </div>
-
-      <div class="row">
-        <label for="dictFile">dicionario.json</label>
-        <input type="file" id="dictFile" accept="application/json" />
-      </div>
-
-      <div class="row">
-        <label for="dictPaste">Colar JSON (opcional)</label>
-        <textarea id="dictPaste" rows="4" placeholder='["casa","livro","sol"] ou {"words":["..."]}'></textarea>
-      </div>
-
-      <div class="row" style="justify-content:space-between">
-        <button id="btnGenerate">Gerar cruzada</button>
-        <button id="btnReset" class="secondary">Limpar</button>
-      </div>
-
-      <div class="row help">Dica: a <strong>primeira palavra</strong> fica com a <em>letra do meio</em> no centro do grid (para pares, usamos o índice <code>Math.floor((len-1)/2)</code>). A orientação alterna entre cada palavra.</div>
-    </section>
-  </div>
-
-  <div class="wrap">
-    <!-- Painel direito: canvas + logs -->
-    <section class="grid-wrap">
-      <div class="panel" style="flex:1; display:flex; flex-direction:column; gap:10px;">
-        <h2>Canvas</h2>
+    <div class="wrap">
+      <section class="grid-wrap">
         <canvas id="board" width="720" height="720"></canvas>
-      </div>
-      <div class="panel" style="width:380px; display:flex; flex-direction:column; gap:10px;">
-        <h2>Resultado</h2>
-        <div id="summary" class="list"></div>
-        <h2>Logs</h2>
-        <div id="logs" class="log" style="height:280px; overflow:auto"></div>
-      </div>
-    </section>
+      </section>
     </div>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -303,110 +303,30 @@
       // ================================================================
       const els = {
         canvas: document.getElementById('board'),
-        gridSize: document.getElementById('gridSize'),
-        minWords: document.getElementById('minWords'),
-        maxWords: document.getElementById('maxWords'),
-        cellSize: document.getElementById('cellSize'),
-        fontScale: document.getElementById('fontScale'),
-        seed: document.getElementById('seed'),
-        dictFile: document.getElementById('dictFile'),
-        dictPaste: document.getElementById('dictPaste'),
-        btnGenerate: document.getElementById('btnGenerate'),
-        btnReset: document.getElementById('btnReset'),
-        logs: document.getElementById('logs'),
-        summary: document.getElementById('summary'),
+        startScreen: document.getElementById('startScreen'),
+        startBtn: document.getElementById('startBtn'),
       };
-      const cfgToggle = document.getElementById('cfgToggle');
-      const configPanel = document.getElementById('configPanel');
   
       const defaultDict = ["casa","computador","livro","sol","mesa","janela","porta","carro","amigo","floresta","rio","luz","tempo","caminho","sorriso","brasil","noite","tarde","manhã","cidade","praia","montanha","vila","cachorro","gato","festa","musica","vento","chuva","neve"];
   
       let placer = null;
   
-      function readUserDictionary(){
-        // Prioridade: textarea > arquivo > default
-        const pasted = els.dictPaste.value.trim();
-        if(pasted){
-          try{
-            const j = JSON.parse(pasted);
-            return Array.isArray(j) ? j : (j && Array.isArray(j.words) ? j.words : defaultDict);
-          }catch(e){
-            alert('JSON inválido no campo de colagem. Usando dicionário padrão.');
-            return defaultDict;
-          }
-        }
-        const file = els.dictFile.files && els.dictFile.files[0];
-        if(file){
-          // Atenção: leitura assíncrona. Aqui retornamos uma Promise que resolve para o array.
-          return new Promise((resolve)=>{
-            const fr = new FileReader();
-            fr.onload = ()=>{
-              try{
-                const j = JSON.parse(fr.result);
-                resolve(Array.isArray(j) ? j : (j && Array.isArray(j.words) ? j.words : defaultDict));
-              }catch(e){ resolve(defaultDict); }
-            };
-            fr.onerror = ()=>resolve(defaultDict);
-            fr.readAsText(file);
-          });
-        }
-        return defaultDict;
-      }
-  
-      function printSummary(placed){
-        if(!placed || !placed.length){ els.summary.innerHTML = '<em>Nenhuma palavra posicionada.</em>'; return; }
-        const items = placed.map((p,i)=>{
-          const span = `<span class="badge">${p.orientation}</span>`;
-          return `<div class="kvs"><div><strong>${i+1}. ${p.word}</strong> ${span}</div><div>(${p.start.row},${p.start.col})</div></div>`;
-        }).join('');
-        els.summary.innerHTML = items;
-      }
-  
-      function flushLogs(){ els.logs.textContent = placer ? placer.logs.join('\n') : ''; }
-  
-      async function generate(){
-        const gridSize = parseInt(els.gridSize.value)||30;
-        const minWords = parseInt(els.minWords.value)||2;
-        const maxWords = parseInt(els.maxWords.value)||5;
-        const cellSize = parseInt(els.cellSize.value)||24;
-        const fontScale = parseInt(els.fontScale.value)||70;
-        const seed = els.seed.value.trim();
-  
-        let dictData = await readUserDictionary();
-        // Caso FileReader retornou Promise
-        if(dictData && typeof dictData.then === 'function'){
-          dictData = await dictData;
-        }
-  
-        placer = new WordPlacer({gridSize, minWords, maxWords, dictionary: dictData, seed});
-        placer.reset();
-        // Normaliza dicionário para uppercase
-        placer.loadDictionary(dictData);
-        // Substitui dicionário por uppercase internamente (feito em getter)
-  
-        const placed = placer.placeWords();
-        placer.drawOnCanvas(els.canvas, {cellSize, fontScale});
-        printSummary(placed);
-        flushLogs();
-      }
-  
-      function resetAll(){
-        if(!placer){
-          const gridSize = parseInt(els.gridSize.value)||30;
-          placer = new WordPlacer({gridSize});
-        }
-        placer.reset();
-        placer.drawOnCanvas(els.canvas, {cellSize: parseInt(els.cellSize.value)||24, fontScale: parseInt(els.fontScale.value)||70});
-        els.summary.innerHTML = '';
-        flushLogs();
-      }
-  
-      // Eventos
-      els.btnGenerate.addEventListener('click', generate);
-      els.btnReset.addEventListener('click', resetAll);
-      cfgToggle.addEventListener('click', () => {
-        configPanel.classList.toggle('open');
-      });
+      function generate(){
+        const gridSize = 30;
+        const minWords = 2;
+        const maxWords = 5;
+        const cellSize = 24;
+        const fontScale = 70;
+        const dictData = defaultDict;
 
-      // Render inicial
-      resetAll();
+        placer = new WordPlacer({gridSize, minWords, maxWords, dictionary: dictData});
+        placer.reset();
+        placer.loadDictionary(dictData);
+        placer.placeWords();
+        placer.drawOnCanvas(els.canvas, {cellSize, fontScale});
+      }
+
+      els.startBtn.addEventListener('click', () => {
+        els.startScreen.classList.add('hidden');
+        generate();
+      });

--- a/styles.css
+++ b/styles.css
@@ -1,65 +1,47 @@
-
 :root{
-    --bg:#0f172a; /* slate-900 */
-    --panel:#111827; /* gray-900 */
-    --ink:#e5e7eb; /* gray-200 */
-    --muted:#9ca3af; /* gray-400 */
-    --accent:#22d3ee; /* cyan-400 */
-  }
-  *{box-sizing:border-box}
-  html,body{height:100%}
-  body{
-    margin:0; font-family:system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
-    background:linear-gradient(160deg,#0b1026,#0f172a 40%, #0b122f);
-    color:var(--ink);
-    display:flex; flex-direction:column;
-  }
-  header{
-    padding:16px 20px; border-bottom:1px solid #1f2937; position:sticky; top:0; backdrop-filter:saturate(1.1) blur(6px); background:rgba(7,12,30,.6);
-  }
-  h1{margin:0; font-size:18px; letter-spacing:.2px}
-  .wrap{padding:16px;}
-  #configPanel{
-    position:fixed;
-    top:0;
-    left:0;
-    height:100%;
-    width:360px;
-    padding:16px;
-    transform:translateX(-100%);
-    transition:transform .3s ease;
-  }
-  #configPanel.open{transform:translateX(0);}
-  #cfgToggle{
-    position:absolute;
-    top:16px;
-    right:20px;
-    background:none;
-    border:0;
-    font-size:20px;
-    color:var(--ink);
-    cursor:pointer;
-  }
-  .panel{background:rgba(17,24,39,.7); border:1px solid #1f2937; border-radius:16px; padding:14px}
-  .panel h2{margin:0 0 10px 0; font-size:14px; color:var(--muted); font-weight:600; letter-spacing:.3px}
-  .row{display:flex; gap:8px; align-items:center; margin:8px 0}
-  label{font-size:12px; color:var(--muted); min-width:120px}
-  input[type="number"], input[type="text"], textarea, select{
-    width:100%; background:#0b1227; border:1px solid #1f2937; color:var(--ink); padding:8px 10px; border-radius:10px; outline:none;
-  }
-  input[type="file"]{width:100%}
-  button{
-    appearance:none; border:0; background:linear-gradient(135deg,#06b6d4,#22d3ee); color:#001018; font-weight:700; padding:10px 14px; border-radius:12px; cursor:pointer; box-shadow:0 6px 20px rgba(34,211,238,.25);
-  }
-  button.secondary{background:#0b1227; color:var(--ink); border:1px solid #1f2937; box-shadow:none}
-  .grid-wrap{display:flex; gap:16px; height:100%;}
-  canvas{background:#0b1227; border:1px solid #1f2937; border-radius:16px; image-rendering:pixelated;}
-  .log{white-space:pre-wrap; background:#0b1227; border:1px solid #1f2937; border-radius:12px; padding:10px; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; color:#cbd5e1; font-size:12px;}
-  .list{font-size:12px; color:#cbd5e1}
-  .badge{display:inline-block; padding:2px 8px; border-radius:999px; background:#0b1227; border:1px solid #1f2937; margin-left:6px; color:#93c5fd}
-  .kvs{display:grid; grid-template-columns: 1fr auto; gap:6px}
-  .help{font-size:12px; color:#a5b4fc}
-  .two{display:grid; grid-template-columns:1fr 1fr; gap:8px}
-  .two .row{flex-direction:column; align-items:flex-start}
-  .two .row label{min-width:unset}
-  .two .row input[type="number"]{max-width:100%}
+  --bg:#0f172a;
+  --panel:#111827;
+  --ink:#e5e7eb;
+  --muted:#9ca3af;
+  --accent:#22d3ee;
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+  margin:0;
+  font-family:system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial,"Apple Color Emoji","Segoe UI Emoji";
+  background:linear-gradient(160deg,#0b1026,#0f172a 40%, #0b122f);
+  color:var(--ink);
+}
+.wrap{padding:16px;}
+.grid-wrap{display:flex; justify-content:center;}
+button{
+  appearance:none;
+  border:0;
+  background:linear-gradient(135deg,#06b6d4,#22d3ee);
+  color:#001018;
+  font-weight:700;
+  padding:10px 14px;
+  border-radius:12px;
+  cursor:pointer;
+  box-shadow:0 6px 20px rgba(34,211,238,.25);
+}
+canvas{
+  background:#0b1227;
+  border:1px solid #1f2937;
+  border-radius:16px;
+  image-rendering:pixelated;
+}
+#startScreen{
+  position:fixed;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:var(--bg);
+  z-index:10;
+}
+#startScreen.hidden{display:none;}


### PR DESCRIPTION
## Summary
- Remove configuration and result panels, replacing with a start screen
- Hardcode default game settings and trigger generation from start button
- Add minimal styling for new start screen overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab915e0b14832eb896f0dfab024a0f