### PR TITLE
Add help modal with overlay and toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
     <button id="cfgToggle">⚙️</button>
   </header>
 
+  <button id="helpBtn">?</button>
+
   <div id="configPanel">
     <section class="panel" id="controls">
       <h2>Configurações</h2>
@@ -62,8 +64,6 @@
         <button id="btnGenerate">Gerar cruzada</button>
         <button id="btnReset" class="secondary">Limpar</button>
       </div>
-
-      <div class="row help">Dica: a <strong>primeira palavra</strong> fica com a <em>letra do meio</em> no centro do grid (para pares, usamos o índice <code>Math.floor((len-1)/2)</code>). A orientação alterna entre cada palavra.</div>
     </section>
   </div>
 
@@ -82,6 +82,9 @@
       </div>
     </section>
     </div>
+
+    <div id="helpOverlay"></div>
+    <div id="helpModal">Dica: a <strong>primeira palavra</strong> fica com a <em>letra do meio</em> no centro do grid (para pares, usamos o índice <code>Math.floor((len-1)/2)</code>). A orientação alterna entre cada palavra.</div>
 
     <script src="script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -318,6 +318,9 @@
       };
       const cfgToggle = document.getElementById('cfgToggle');
       const configPanel = document.getElementById('configPanel');
+      const helpBtn = document.getElementById('helpBtn');
+      const helpModal = document.getElementById('helpModal');
+      const helpOverlay = document.getElementById('helpOverlay');
   
       const defaultDict = ["casa","computador","livro","sol","mesa","janela","porta","carro","amigo","floresta","rio","luz","tempo","caminho","sorriso","brasil","noite","tarde","manhã","cidade","praia","montanha","vila","cachorro","gato","festa","musica","vento","chuva","neve"];
   
@@ -406,6 +409,15 @@
       els.btnReset.addEventListener('click', resetAll);
       cfgToggle.addEventListener('click', () => {
         configPanel.classList.toggle('open');
+      });
+      helpBtn.addEventListener('click', () => {
+        const show = !helpModal.classList.contains('show');
+        helpModal.classList.toggle('show', show);
+        helpOverlay.classList.toggle('show', show);
+      });
+      helpOverlay.addEventListener('click', () => {
+        helpModal.classList.remove('show');
+        helpOverlay.classList.remove('show');
       });
 
       // Render inicial

--- a/styles.css
+++ b/styles.css
@@ -63,3 +63,37 @@
   .two .row{flex-direction:column; align-items:flex-start}
   .two .row label{min-width:unset}
   .two .row input[type="number"]{max-width:100%}
+  #helpBtn{
+    position:fixed;
+    top:16px;
+    right:60px;
+    width:32px;
+    height:32px;
+    border-radius:50%;
+    padding:0;
+    line-height:32px;
+    font-weight:700;
+  }
+  #helpOverlay{
+    position:fixed;
+    inset:0;
+    background:rgba(0,0,0,.6);
+    display:none;
+    z-index:1000;
+  }
+  #helpModal{
+    position:fixed;
+    top:50%;
+    left:50%;
+    transform:translate(-50%,-50%);
+    background:var(--panel);
+    border:1px solid #1f2937;
+    border-radius:12px;
+    padding:20px;
+    max-width:320px;
+    font-size:14px;
+    display:none;
+    z-index:1001;
+  }
+  #helpOverlay.show,
+  #helpModal.show{display:block}


### PR DESCRIPTION
## Summary
- add help button, modal, and overlay to display cross puzzle hint
- style new UI elements with fixed positioning and backdrop
- wire up JS to toggle help modal and hide on overlay click

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab91c0c4f8832eb5fb4b6f780895bf