### PR TITLE
Add help modal and overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,20 @@
   <link rel="stylesheet" href="styles.css">
 </head>
   <body>
-    <div id="startScreen">
-      <button id="startBtn">Iniciar jogo</button>
-    </div>
+  <div id="startScreen">
+    <button id="startBtn">Iniciar jogo</button>
+  </div>
 
-    <div class="wrap">
-      <section class="grid-wrap">
-        <canvas id="board" width="720" height="720"></canvas>
-      </section>
+  <button id="helpBtn">?</button>
+  <div id="helpOverlay" class="hidden"></div>
+  <div id="helpModal" class="hidden">
+    <p>Dica: Clique em "Iniciar jogo" para gerar o tabuleiro.</p>
+  </div>
+
+  <div class="wrap">
+    <section class="grid-wrap">
+      <canvas id="board" width="720" height="720"></canvas>
+    </section>
     </div>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -301,11 +301,14 @@
       // ================================================================
       // App: integra UI + Canvas + WordPlacer
       // ================================================================
-      const els = {
-        canvas: document.getElementById('board'),
-        startScreen: document.getElementById('startScreen'),
-        startBtn: document.getElementById('startBtn'),
-      };
+        const els = {
+          canvas: document.getElementById('board'),
+          startScreen: document.getElementById('startScreen'),
+          startBtn: document.getElementById('startBtn'),
+          helpBtn: document.getElementById('helpBtn'),
+          helpModal: document.getElementById('helpModal'),
+          helpOverlay: document.getElementById('helpOverlay'),
+        };
   
       const defaultDict = ["casa","computador","livro","sol","mesa","janela","porta","carro","amigo","floresta","rio","luz","tempo","caminho","sorriso","brasil","noite","tarde","manhã","cidade","praia","montanha","vila","cachorro","gato","festa","musica","vento","chuva","neve"];
   
@@ -338,7 +341,17 @@
         console.log(placer.logs.join('\n'));
       }
 
-      els.startBtn.addEventListener('click', () => {
-        els.startScreen.classList.add('hidden');
-        generate();
-      });
+        els.startBtn.addEventListener('click', () => {
+          els.startScreen.classList.add('hidden');
+          generate();
+        });
+
+        els.helpBtn.addEventListener('click', () => {
+          els.helpModal.classList.toggle('hidden');
+          els.helpOverlay.classList.toggle('hidden');
+        });
+
+        els.helpOverlay.addEventListener('click', () => {
+          els.helpModal.classList.add('hidden');
+          els.helpOverlay.classList.add('hidden');
+        });

--- a/styles.css
+++ b/styles.css
@@ -45,3 +45,40 @@ canvas{
   z-index:10;
 }
 #startScreen.hidden{display:none;}
+
+.hidden{display:none;}
+
+#helpBtn{
+  position:fixed;
+  top:10px;
+  right:10px;
+  width:40px;
+  height:40px;
+  border-radius:50%;
+  font-size:20px;
+  font-weight:700;
+  z-index:20;
+}
+
+#helpOverlay{
+  position:fixed;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  background:rgba(0,0,0,.6);
+  z-index:30;
+}
+
+#helpModal{
+  position:fixed;
+  top:50%;
+  left:50%;
+  transform:translate(-50%,-50%);
+  background:var(--panel);
+  padding:20px;
+  border-radius:12px;
+  max-width:90%;
+  width:320px;
+  z-index:40;
+}


### PR DESCRIPTION
## Summary
- Add help button and modal overlay with instructions
- Style help elements with fixed positions and backdrop
- Hook up script handlers to toggle help modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab936ea858832eaa34af78924c1684