### PR TITLE
Add grid inputs overlay and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <div class="wrap">
     <section class="grid-wrap">
       <canvas id="board" width="720" height="720"></canvas>
+      <div id="gridInputs"></div>
     </section>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@ body{
   color:var(--ink);
 }
 .wrap{padding:16px;}
-.grid-wrap{display:flex; justify-content:center;}
+.grid-wrap{display:flex; justify-content:center; position:relative;}
 button{
   appearance:none;
   border:0;
@@ -31,6 +31,23 @@ canvas{
   border:1px solid #1f2937;
   border-radius:16px;
   image-rendering:pixelated;
+}
+#gridInputs{
+  position:absolute;
+  top:0;
+  left:0;
+  display:grid;
+}
+.cell-input{
+  width:var(--cellSize);
+  height:var(--cellSize);
+  text-align:center;
+  border:1px solid transparent;
+  background:transparent;
+  color:var(--ink);
+  font-size:calc(var(--cellSize)*0.6);
+  padding:0;
+  margin:0;
 }
 #startScreen{
   position:fixed;


### PR DESCRIPTION
## Summary
- Overlay editable input grid on top of crossword canvas
- Style grid inputs to match cell size
- Add event-driven focus navigation and character filtering

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aba2cfdcbc832e916c72146da03331