### PR TITLE
Add letter inputs overlay on canvas crossword board

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@
 
   <div class="wrap">
     <section class="grid-wrap">
-      <div id="board" class="board-grid"></div>
+      <canvas id="board"></canvas>
+      <div id="gridInputs"></div>
     </section>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -13,8 +13,8 @@ body{
   background:linear-gradient(160deg,#0b1026,#0f172a 40%, #0b122f);
   color:var(--ink);
 }
-.wrap{padding:16px;}
-.grid-wrap{display:flex; justify-content:center;}
+.wrap{padding:16px; display:flex; justify-content:center;}
+.grid-wrap{position:relative;}
 button{
   appearance:none;
   border:0;
@@ -33,17 +33,18 @@ canvas{
   image-rendering:pixelated;
 }
 
-.board-grid{
-  background:#0b1227;
-  border:1px solid #1f2937;
-  border-radius:16px;
+#gridInputs{
+  position:absolute;
+  top:0;
+  left:0;
 }
 
-.cell{
-  width:24px;
-  height:24px;
+.cell-input{
+  position:absolute;
+  width:var(--cell-size);
+  height:var(--cell-size);
   text-align:center;
-  border:1px solid #1f2937;
+  border:0;
   background:transparent;
   color:var(--ink);
   font-size:16px;


### PR DESCRIPTION
## Summary
- restore canvas board and overlay absolute input container for each word cell
- style input overlay and grid container for proper alignment
- restrict inputs to uppercase A-Z and auto-focus navigation across words

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abaae618b8832eaf2fe7122bb34ef7