### PR TITLE
feat: add input validation for placed words

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,6 +50,29 @@ canvas{
   font-size:16px;
   text-transform:uppercase;
 }
+
+.check-btn{
+  position:absolute;
+  width:var(--cell-size);
+  height:var(--cell-size);
+  padding:0;
+  font-size:16px;
+}
+
+.cell-input.correct{
+  background:#16a34a;
+  color:#fff;
+}
+
+.cell-input.present{
+  background:#facc15;
+  color:#000;
+}
+
+.cell-input.absent{
+  background:#374151;
+  color:#fff;
+}
 #startScreen{
   position:fixed;
   top:0;


### PR DESCRIPTION
## Summary
- track inputs for each placed word and show a positioned check button when all letters are filled
- validate guessed letters against the word, styling with correct/present/absent classes
- style validation states and check button in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc8a7c824832ebdb5e83618f70a19