### PR TITLE
Add lives system with UI and loss handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
     <p>Dica: Clique em "Iniciar jogo" para gerar o tabuleiro.</p>
   </div>
 
+  <div id="lives"><span id="heart">❤</span><span id="lifeCount">5</span></div>
+
   <div class="wrap">
     <section class="grid-wrap">
       <canvas id="board"></canvas>

--- a/script.js
+++ b/script.js
@@ -368,13 +368,25 @@
           helpBtn: document.getElementById('helpBtn'),
           helpModal: document.getElementById('helpModal'),
           helpOverlay: document.getElementById('helpOverlay'),
+          lifeCount: document.getElementById('lifeCount'),
         };
   
       const defaultDict = ["casa","computador","livro","sol","mesa","janela","porta","carro","amigo","floresta","rio","luz","tempo","caminho","sorriso","brasil","noite","tarde","manhã","cidade","praia","montanha","vila","cachorro","gato","festa","musica","vento","chuva","neve"];
   
       let placer = null;
+      let lives = 5;
 
       let activeOrientation = 'horizontal';
+
+      function loseLife(){
+        lives--;
+        els.lifeCount.textContent = lives;
+        if(lives <= 0){
+          const disabled = els.gridInputs.querySelectorAll('input, button');
+          disabled.forEach(el => el.disabled = true);
+          alert('Fim de jogo!');
+        }
+      }
 
       function moveFocus(current, forward=true){
         const r = parseInt(current.dataset.row, 10);
@@ -433,6 +445,8 @@
 
         if(wordObj.inputs.every(inp => inp.classList.contains('correct'))){
           wordObj.checkBtn.disabled = true;
+        } else {
+          loseLife();
         }
       }
 
@@ -530,6 +544,9 @@
         const cellSize = 24;
         const fontScale = 70;
         const dictData = defaultDict;
+
+        lives = 5;
+        els.lifeCount.textContent = lives;
 
         placer = new WordPlacer({gridSize, minWords, maxWords, dictionary: dictData});
         placer.reset();

--- a/styles.css
+++ b/styles.css
@@ -123,3 +123,14 @@ canvas{
   width:320px;
   z-index:40;
 }
+
+#lives{
+  position:fixed;
+  top:10px;
+  right:60px;
+  z-index:20;
+}
+
+#lifeCount{
+  color:red;
+}


### PR DESCRIPTION
## Summary
- Add lives display to the page and style it
- Track lives in the game logic with loseLife handler
- Decrement lives on incorrect word checks and end game when exhausted

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abef7b22d0832e862bb5c6d87c777d