### PR TITLE
Add victory and game-over modals with restart option

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,12 @@
     <p>Dica: Clique em "Iniciar jogo" para gerar o tabuleiro.</p>
   </div>
 
+  <div id="msgOverlay" class="hidden"></div>
+  <div id="msgModal" class="hidden">
+    <p id="msgText"></p>
+    <button id="restartBtn">Reiniciar</button>
+  </div>
+
   <div id="lives"><span id="heart">❤</span><span id="lifeCount">5</span></div>
 
   <div class="wrap">

--- a/script.js
+++ b/script.js
@@ -369,6 +369,10 @@
           helpModal: document.getElementById('helpModal'),
           helpOverlay: document.getElementById('helpOverlay'),
           lifeCount: document.getElementById('lifeCount'),
+          msgOverlay: document.getElementById('msgOverlay'),
+          msgModal: document.getElementById('msgModal'),
+          msgText: document.getElementById('msgText'),
+          restartBtn: document.getElementById('restartBtn'),
         };
   
       const defaultDict = ["casa","computador","livro","sol","mesa","janela","porta","carro","amigo","floresta","rio","luz","tempo","caminho","sorriso","brasil","noite","tarde","manhã","cidade","praia","montanha","vila","cachorro","gato","festa","musica","vento","chuva","neve"];
@@ -378,13 +382,30 @@
 
       let activeOrientation = 'horizontal';
 
+      function hideMessage(){
+        els.msgOverlay.classList.add('hidden');
+        els.msgModal.classList.add('hidden');
+        els.restartBtn.classList.add('hidden');
+      }
+
+      function showMessage(text, showRestart = false){
+        els.msgText.textContent = text;
+        els.msgOverlay.classList.remove('hidden');
+        els.msgModal.classList.remove('hidden');
+        const disabled = els.gridInputs.querySelectorAll('input, button');
+        disabled.forEach(el => el.disabled = true);
+        if(showRestart){
+          els.restartBtn.classList.remove('hidden');
+        }else{
+          els.restartBtn.classList.add('hidden');
+        }
+      }
+
       function loseLife(){
         lives--;
         els.lifeCount.textContent = lives;
         if(lives <= 0){
-          const disabled = els.gridInputs.querySelectorAll('input, button');
-          disabled.forEach(el => el.disabled = true);
-          alert('Fim de jogo!');
+          showMessage('Fim de jogo!', true);
         }
       }
 
@@ -447,6 +468,13 @@
           wordObj.checkBtn.disabled = true;
         } else {
           loseLife();
+        }
+        checkVictory();
+      }
+
+      function checkVictory(){
+        if(placer && placer.placed.every(p => p.inputs && p.inputs.every(inp => inp.classList.contains('correct')))){
+          showMessage('Você venceu!', true);
         }
       }
 
@@ -547,6 +575,8 @@
 
         lives = 5;
         els.lifeCount.textContent = lives;
+        hideMessage();
+        els.restartBtn.classList.add('hidden');
 
         placer = new WordPlacer({gridSize, minWords, maxWords, dictionary: dictData});
         placer.reset();
@@ -580,5 +610,10 @@
 
         els.helpOverlay.addEventListener('click', () => {
           els.helpModal.classList.add('hidden');
-          els.helpOverlay.classList.add('hidden');
-        });
+        els.helpOverlay.classList.add('hidden');
+      });
+
+      els.restartBtn.addEventListener('click', () => {
+        hideMessage();
+        generate();
+      });

--- a/styles.css
+++ b/styles.css
@@ -134,3 +134,29 @@ canvas{
 #lifeCount{
   color:red;
 }
+
+#msgOverlay{
+  position:fixed;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  background:rgba(0,0,0,.6);
+  z-index:50;
+}
+
+#msgModal{
+  position:fixed;
+  top:50%;
+  left:50%;
+  transform:translate(-50%,-50%);
+  background:var(--panel);
+  padding:20px;
+  border-radius:12px;
+  max-width:90%;
+  width:320px;
+  text-align:center;
+  z-index:60;
+}
+
+#msgModal button{margin-top:10px;}


### PR DESCRIPTION
## Summary
- Add reusable modal overlay with restart button for victory or game over
- Track completion of all words and show victory banner
- Reset and regenerate board when player restarts after game over

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abf0504408832ebb5534b374174316