### PR TITLE
Hide grid and add field borders

### DIFF
--- a/script.js
+++ b/script.js
@@ -134,14 +134,7 @@
           ctx.fillStyle = '#0b1227';
           ctx.fillRect(0,0,canvas.width, canvas.height);
   
-          // Linhas
-          ctx.strokeStyle = '#1f2937';
-          ctx.lineWidth = 1;
-          for(let i=0;i<=this.gridSize;i++){
-            const p = i*cellSize + .5;
-            ctx.beginPath(); ctx.moveTo(.5, p); ctx.lineTo(canvas.width-.5, p); ctx.stroke();
-            ctx.beginPath(); ctx.moveTo(p, .5); ctx.lineTo(p, canvas.height-.5); ctx.stroke();
-          }
+          // Linhas removidas para esconder o grid
   
           // Letras
           ctx.fillStyle = '#e5e7eb';

--- a/styles.css
+++ b/styles.css
@@ -44,7 +44,7 @@ canvas{
   width:var(--cell-size);
   height:var(--cell-size);
   text-align:center;
-  border:0;
+  border:1px solid #1f2937;
   background:transparent;
   color:var(--ink);
   font-size:16px;


### PR DESCRIPTION
## Summary
- remove grid line rendering on board canvas to hide the grid
- add 1px border around input cells for visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abf5f0f934832ea69a7d079d5868c0