### PR TITLE
Focus first input after puzzle generation

### DIFF
--- a/script.js
+++ b/script.js
@@ -651,6 +651,11 @@
         placer.drawOnCanvas(els.canvas, {cellSize, fontScale, showLetters:false});
         createInputs(placer);
         buildKeyboard();
+        const firstInput = els.gridInputs.querySelector('.cell-input');
+        if(firstInput){
+          firstInput.focus();
+          activeOrientation = (firstInput.dataset.orientation || '').split(',')[0] || 'horizontal';
+        }
         printSummary();
         flushLogs();
       }


### PR DESCRIPTION
## Summary
- Focus the first crossword cell after keyboard creation
- Initialize navigation orientation from the first cell's data

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac113d9bc8832e930ce8d1efc02298