### PR TITLE
Focus first crossword cell when using onscreen keyboard

### DIFF
--- a/script.js
+++ b/script.js
@@ -432,8 +432,16 @@
 
       function handleKeyClick(e){
         const key = e.currentTarget.dataset.key;
-        const active = document.activeElement;
-        if(!active || !active.classList.contains('cell-input')) return;
+        let active = document.activeElement;
+        if(!active || !active.classList.contains('cell-input')){
+          const first = els.gridInputs.querySelector('.cell-input');
+          if(first){
+            first.focus();
+            active = first;
+          } else {
+            return;
+          }
+        }
 
         if(key === 'BACKSPACE'){
           if(active.value !== ''){


### PR DESCRIPTION
## Summary
- Ensure virtual keyboard uses the first cell if no input is focused

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1388dff4832ea0f8a1bb7c94b1db